### PR TITLE
Noref: Correct port forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-EXPOSE 8080
+EXPOSE 3000
 CMD [ "node", "server.js" ]

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@
 const express = require('express');
 
 // Constants
-const PORT = 8080;
+const PORT = 3000;
 const HOST = '0.0.0.0';
 
 // App


### PR DESCRIPTION
There is a discrepancy of port forwarding between README.md (3000) and
    server.js + Dockerfile (8080), so I rewrite all port 8080 to 3000.